### PR TITLE
Add http max idle connections flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Parameters
 * --vusigned : number of accounts for signed transaction to use in test case.
 * --vuunsigned: number of accounts for unsigned transaction to use in test case.
 * --endpoint: klay node rpc endpoint(e.g. http://localhost:8551).
+* --http.maxidleconns: maximum number of idle connections in default http client (default 100).
 
 ## How to contribute?
 * issue: Please make an issue if there's bug, improvement, docs suggestion, etc.

--- a/klayslave/main.go
+++ b/klayslave/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"net/http"
 	"os"
 	"runtime"
 	"strings"
@@ -442,6 +443,7 @@ func initArgs(tcNames string) {
 	keyPtr := flag.String("key", "", "privatekey of coinbase")
 	chargeKLAYAmountPtr := flag.Int("charge", chargeKLAYAmount, "charging amount for each test account in KLAY")
 	versionPtr := flag.Bool("version", false, "show version number")
+	httpMaxIdleConnsPtr := flag.Int("http.maxidleconns", 100, "maximum number of idle connections in default http client")
 	flag.StringVar(&tcStr, "tc", tcNames, "tasks which user want to run, multiple tasks are separated by comma.")
 
 	flag.Parse()
@@ -453,6 +455,12 @@ func initArgs(tcNames string) {
 
 	if *keyPtr == "" {
 		log.Fatal("key argument is not defined. You should set the key for coinbase.\n example) klaytc -key='2ef07640fd8d3f568c23185799ee92e0154bf08ccfe5c509466d1d40baca3430'")
+	}
+
+	// setup default http client.
+	if tr, ok := http.DefaultTransport.(*http.Transport); ok {
+		tr.MaxIdleConns = *httpMaxIdleConnsPtr
+		tr.MaxIdleConnsPerHost = *httpMaxIdleConnsPtr
 	}
 
 	// for TC Selection


### PR DESCRIPTION
Configure max idle connections of the default http client by using `--http.maxidleconns` flag.

DefaultTransport in http package uses 100 and 2 as default values for `MaxIdleConns` and `MaxIdleConnsPerHost`.
That means 98 connections will be closed if 100 clients request at the same time because of `MaxIdleConnsPerHost`,
can cause `TIME_WAIT` or other problems (See - [마이크로 서비스와 TIME_WAIT 문제](https://www.popit.kr/%EB%A7%88%EC%9D%B4%ED%81%AC%EB%A1%9C-%EC%84%9C%EB%B9%84%EC%8A%A4%EC%99%80-time_wait-%EB%AC%B8%EC%A0%9C/))

If sets 500 users in locust test, below error occurs.
```
Account(0x9353DC1fCf0884D0c485B26c89d4c03D1D7a9fb5) nonce(92) : Failed to sendTrasnaction: Post "http://3.36.105.206:8553/": dial tcp 3.36.105.206:8553: connect: can't assign requested address
```

<img width="1590" alt="스크린샷 2022-05-11 오전 9 10 58" src="https://user-images.githubusercontent.com/25560203/167744132-b5ecede7-1d84-44b0-9408-1e6f753489e8.png">