### PR TITLE
support klaytn-deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN make && cp $SRC_DIR/build/bin/klayslave /bin/
 FROM python:3.7-buster
 
 RUN pip3 install locust==1.2.3
-RUN mkdir -p /locust-docker-pkg 
+RUN mkdir -p /locust-docker-pkg/bin
 
-COPY --from=builder /bin/klayslave /locust-docker-pkg/klayslave
-RUN ln -s /locust-docker-pkg/klayslave /bin/klayslave
+COPY --from=builder /bin/klayslave /locust-docker-pkg/bin/klayslave
+RUN ln -s /locust-docker-pkg/bin/klayslave /bin/klayslave

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,7 @@ RUN make && cp $SRC_DIR/build/bin/klayslave /bin/
 FROM python:3.7-buster
 
 RUN pip3 install locust==1.2.3
+RUN mkdir -p /locust-docker-pkg 
 
-COPY --from=builder /bin/klayslave /bin/klayslave
+COPY --from=builder /bin/klayslave /locust-docker-pkg/klayslave
+RUN ln -s /locust-docker-pkg/klayslave /bin/klayslave


### PR DESCRIPTION
I got reported `klaytn-deploy` is using Dockerfile of `klaytn-load-tester` to get Ubuntu binary file.
So new Dockerfile need keep legacy binary path, `/locust-docker-pkg/klayslave`.
