### PR TITLE
add locustfile.py to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,11 @@ ADD . .
 RUN make && cp $SRC_DIR/build/bin/klayslave /bin/
 
 FROM python:3.7-buster
+ENV SRC_DIR /go/src/github.com/klaytn/klaytn-load-tester
 
 RUN pip3 install locust==1.2.3
 RUN mkdir -p /locust-docker-pkg/bin
 
 COPY --from=builder /bin/klayslave /locust-docker-pkg/bin/klayslave
+COPY --from=builder $SRC_DIR/dist/locustfile.py /locust-docker-pkg/locustfile.py 
 RUN ln -s /locust-docker-pkg/bin/klayslave /bin/klayslave

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
+ARG SRC_DIR=/go/src/github.com/klaytn/klaytn-load-tester
+
 FROM golang:1.18-buster as builder
+ARG SRC_DIR
 
 RUN apt update && apt install -y make
 
-ENV SRC_DIR /go/src/github.com/klaytn/klaytn-load-tester
 ENV GOPATH /go
 
 WORKDIR $SRC_DIR
@@ -11,7 +13,7 @@ ADD . .
 RUN make && cp $SRC_DIR/build/bin/klayslave /bin/
 
 FROM python:3.7-buster
-ENV SRC_DIR /go/src/github.com/klaytn/klaytn-load-tester
+ARG SRC_DIR
 
 RUN pip3 install locust==1.2.3
 RUN mkdir -p /locust-docker-pkg/bin


### PR DESCRIPTION
Klaytn-load-tester docker image need to have `locustfile.py` to use Locust master.
So I made this PR to fix it.